### PR TITLE
perf: introduced plaiceholder

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,10 @@
-/** @type {import('next').NextConfig} */
-module.exports = {
+// @ts-check
+import withPlaiceholder from "@plaiceholder/next";
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const config = {
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback.fs = false;
@@ -11,6 +16,7 @@ module.exports = {
     return config;
   },
   env: {
+    // @ts-ignore
     GOOGLE_SERVICE_PRIVATE_KEY: process.env.GOOGLE_SERVICE_PRIVATE_KEY,
   },
   experimental: {
@@ -27,3 +33,5 @@ module.exports = {
     ],
   },
 };
+
+export default withPlaiceholder(config);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@plaiceholder/next": "^3.0.0",
     "@types/node": "20.5.9",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
@@ -30,6 +31,7 @@
     "google-auth-library": "^9.1.0",
     "google-spreadsheet": "^4.1.0",
     "next": "13.4.19",
+    "plaiceholder": "^3.0.0",
     "postcss": "8.4.29",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -11,7 +11,7 @@ import styles from "./AboutUs.module.css";
 import teamPhoto1 from "@assets/images/about-us/team-photo-1.png";
 import teamPhoto2 from "@assets/images/about-us/team-photo-2.png";
 
-export default function AboutUs() {
+export default async function AboutUs() {
   return (
     <>
       <div className="fixed w-full top-0 z-50">

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -1,36 +1,13 @@
-"use client";
-
 import { Footer } from "@components/Footer/Footer";
 import { NavBar } from "@components/NavBar/NavBar";
 import { PageHeader } from "@components/PageHeader/PageHeader";
-import successCheckMark from "@assets/icons/icon-checkmark-success.svg";
 import Image from "next/image";
-import ContactForm, {
-  ContactFormData,
-} from "@components/ContactForm/ContactForm";
+import ContactForm from "@components/ContactForm/ContactForm";
 import atSignIcon from "@assets/icons/at-sign.svg";
 import mapIcon from "@assets/icons/map.svg";
 import phoneIcon from "@assets/icons/phone.svg";
-import { saveToSpreadsheet } from "@lib/actions";
-import { useState } from "react";
 
 export default function ContactUs() {
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-
-  const handleSubmit = async (formData: ContactFormData) => {
-    setLoading(true);
-    const rowData = [
-      formData.fullName,
-      formData.email,
-      formData.mobileNumber,
-      formData.message,
-    ];
-    const result = await saveToSpreadsheet(rowData);
-    setSuccess(result.success);
-    setLoading(false)
-  };
-
   return (
     <>
       <div className="fixed w-full top-0 z-50">
@@ -100,26 +77,8 @@ export default function ContactUs() {
           </div>
         </div>
 
-        {/* form and success  */}
-        <div className="bg-neutral-0 px-8 md:w-[450px] h-[640px] py-6">
-          {loading && (
-            <div className="h-full w-full font-header font-bold text-neutral-800 flex flex-col items-center justify-center gap-1 text-center">
-              <div className="text-h4 my-1">Sending...</div>
-            </div>
-          )}
 
-          {!loading && !success && <ContactForm onSubmit={handleSubmit} />}
-
-          {!loading && success && (
-            <div className="h-full w-full font-header font-bold text-neutral-800 flex flex-col items-center justify-center gap-1 text-center">
-              <Image src={successCheckMark} alt="Success" />
-              <div className="text-h4 my-1">Message sent!</div>
-              <div className="text-h6">
-                Our team will contact you as soon as possible.
-              </div>
-            </div>
-          )}
-        </div>
+        <ContactForm />
       </div>
 
       <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { TestimonialSlider } from "@components/TestimonialSlider/TestimonialSlid
 import { TESTIMONIALS } from "@components/TestimonialSlider/TestimonialSlider.stories";
 import { NavBar } from "@components/NavBar/NavBar";
 import { COMPLETED_PROJECTS } from "./projects/completed-projects.constant";
-
+import getBase64ImageUrl from "@lib/generateBlurPlaceholder";
 
 const CLIENT_LOGOS = [
   {
@@ -89,7 +89,15 @@ const CLIENT_LOGOS = [
   },
 ];
 
-export default function Home() {
+
+
+export default async  function Home() {
+  const pageHeaderImage = {
+    src: '/images/page-headers/landing-page.png',
+    blurDataURL: ''
+  }
+  pageHeaderImage.blurDataURL = await getBase64ImageUrl(pageHeaderImage.src)
+
   return (
     <>
       <div className="fixed w-full top-0 z-50">
@@ -118,8 +126,10 @@ export default function Home() {
         <div className="relative w-full h-full">
           <div className="z-20 h-full w-full absolute bg-neutral-900/75"></div>
           <Image
-            src="/images/page-headers/landing-page.png"
+            src={pageHeaderImage.src}
             alt="360DEGREES SYSTEMS CORPORATION"
+            placeholder="blur"
+            blurDataURL={pageHeaderImage.blurDataURL}
             fill
             className="z-10 object-cover"
             priority

--- a/src/components/ContactForm/ContactForm.stories.tsx
+++ b/src/components/ContactForm/ContactForm.stories.tsx
@@ -8,10 +8,5 @@ export default {
 } as Meta;
 
 export const Default = () => (
-  <ContactForm
-    onSubmit={(formData) => {
-      // Handle form submission data here
-      console.log(formData);
-    }}
-  />
+  <ContactForm />
 );

--- a/src/components/ContactForm/ContactForm.tsx
+++ b/src/components/ContactForm/ContactForm.tsx
@@ -1,68 +1,104 @@
-'use client'
+"use client";
 
-import React, { useState } from 'react';
-import FullNameInput from '@components/FullNameInput/FullNameInput';
-import EmailInput from '@components/EmailInput/EmailInput';
-import MobileNumberInput from '@components/MobileNumberInput/MobileNumberInput';
-import MessageTextarea from '@components/MessageTextarea/MessageTextarea';
+import React, { useState } from "react";
+import Image from "next/image";
+import successCheckMark from "@assets/icons/icon-checkmark-success.svg";
+import FullNameInput from "@components/FullNameInput/FullNameInput";
+import EmailInput from "@components/EmailInput/EmailInput";
+import MobileNumberInput from "@components/MobileNumberInput/MobileNumberInput";
+import MessageTextarea from "@components/MessageTextarea/MessageTextarea";
+import { saveToSpreadsheet } from "@lib/actions";
 
 export type ContactFormData = {
   fullName: string;
   email: string;
   mobileNumber: string;
   message: string;
-}
+};
 
-interface ContactFormProps {
-  onSubmit: (formData: ContactFormData) => void;
-}
 
-const ContactForm: React.FC<ContactFormProps> = ({ onSubmit }) => {
+const ContactForm: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
   const [formData, setFormData] = useState<ContactFormData>({
-    fullName: '',
-    email: '',
-    mobileNumber: '',
-    message: '',
+    fullName: "",
+    email: "",
+    mobileNumber: "",
+    message: "",
   });
 
-  const handleFormSubmit = (e: React.FormEvent) => {
+  const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setLoading(true);
+
     // Check if any of the form fields are empty or null
     const { fullName, email, mobileNumber, message } = formData;
     if (!fullName || !email || !mobileNumber || !message) {
       // You can display an error message or handle it as needed
-      console.error('Please fill in all fields');
+      console.error("Please fill in all fields");
+      setLoading(false);
       return;
     }
 
-    onSubmit(formData);
+    const rowData = [
+      formData.fullName,
+      formData.email,
+      formData.mobileNumber,
+      formData.message,
+    ];
+    const result = await saveToSpreadsheet(rowData);
+    setSuccess(result.success);
+    setLoading(false);
   };
 
   return (
-    <form onSubmit={handleFormSubmit} className="max-w-md mx-auto">
-      <header className='text-h5 lg:text-h4 font-bold text-neutral-800 font-header mb-6 text-center'>
-        Want to have work done?
-      </header>
+    <div className="bg-neutral-0 px-8 md:w-[450px] h-[640px] py-6">
+      {/* SENDING */}
+      {loading && (
+        <div className="h-full w-full font-header font-bold text-neutral-800 flex flex-col items-center justify-center gap-1 text-center">
+          <div className="text-h4 my-1">Sending...</div>
+        </div>
+      )}
 
-      <FullNameInput
-        onBlur={(value) => setFormData({ ...formData, fullName: value })}
-      />
-      <EmailInput
-        onBlur={(value) => setFormData({ ...formData, email: value })}
-      />
-      <MobileNumberInput
-        onBlur={(value) => setFormData({ ...formData, mobileNumber: value })}
-      />
-      <MessageTextarea
-        onBlur={(value) => setFormData({ ...formData, message: value })}
-      />
-      <button
-        type="submit"
-        className="bg-primary-500 hover:bg-primary-200 active:bg-primary-300 transition-colors text-neutral-50 font-bold text-center py-2 px-4 mt-4 w-full"
-      >
-        Submit
-      </button>
-    </form>
+      {/* ACTUAL FORM */}
+      {!loading && !success && (
+        <form onSubmit={handleFormSubmit} className="max-w-md mx-auto">
+          <header className="text-h5 lg:text-h4 font-bold text-neutral-800 font-header mb-6 text-center">
+            Want to have work done?
+          </header>
+
+          <FullNameInput
+            onBlur={(value) => setFormData({ ...formData, fullName: value })}
+          />
+          <EmailInput
+            onBlur={(value) => setFormData({ ...formData, email: value })}
+          />
+          <MobileNumberInput
+            onBlur={(value) =>
+              setFormData({ ...formData, mobileNumber: value })
+            }
+          />
+          <MessageTextarea
+            onBlur={(value) => setFormData({ ...formData, message: value })}
+          />
+          <button
+            type="submit"
+            className="bg-primary-500 hover:bg-primary-200 active:bg-primary-300 transition-colors text-neutral-50 font-bold text-center py-2 px-4 mt-4 w-full">
+            Submit
+          </button>
+        </form>
+      )}
+
+      {!loading && success && (
+        <div className="h-full w-full font-header font-bold text-neutral-800 flex flex-col items-center justify-center gap-1 text-center">
+          <Image src={successCheckMark} alt="Success" />
+          <div className="text-h4 my-1">Message sent!</div>
+          <div className="text-h6">
+            Our team will contact you as soon as possible.
+          </div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,3 +1,4 @@
+import getBase64ImageUrl from "@lib/generateBlurPlaceholder";
 import Image from "next/image";
 
 interface PageHeaderProps {
@@ -5,7 +6,9 @@ interface PageHeaderProps {
   title: string;
 }
 
-export const PageHeader = ({ bgImageSrc, title }: PageHeaderProps) => {
+export const PageHeader = async ({ bgImageSrc, title }: PageHeaderProps) => {
+  const blurDataURL = await getBase64ImageUrl(bgImageSrc)
+
   return (
     <div className="h-72 w-screen relative">
       <header className="absolute w-screen flex justify-center text-center top-1/2 -translate-y-1/3 z-30 m-auto text-h3 lg:text-h1 font-header text-neutral-50 font-bold">
@@ -14,7 +17,7 @@ export const PageHeader = ({ bgImageSrc, title }: PageHeaderProps) => {
 
       <div className="relative w-full h-full">
         <div className="z-20 h-full w-full absolute bg-neutral-900/75"></div>
-        <Image src={bgImageSrc} alt="header" fill className="z-10 object-cover" priority />
+        <Image src={bgImageSrc} placeholder="blur" blurDataURL={blurDataURL} alt="header" fill className="z-10 object-cover" priority />
       </div>
     </div>
   );

--- a/src/lib/generateBlurPlaceholder.ts
+++ b/src/lib/generateBlurPlaceholder.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import { getPlaiceholder } from 'plaiceholder'
+
+const cache = new Map<string, string>()
+
+export default async function getBase64ImageUrl(imageSrc: string): Promise<string> {
+  try {
+    let url = cache.get(imageSrc)
+    if (url) {
+      return url
+    }
+    const imageBuffer = await fetchImage(imageSrc)
+    const { base64 } = await getPlaiceholder(imageBuffer)
+    cache.set(imageSrc, base64)
+    return base64
+  } catch (error) {
+    console.error(error)
+    // default gray radial placeholder`
+    return 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAA4ADgDASIAAhEBAxEB/8QAGgAAAwEBAQEAAAAAAAAAAAAAAAYHCAUBBP/EACUQAAEEAQQDAAIDAAAAAAAAAAIAAQUGIgMREqEEEyEUMjEzQf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwDFMPD+xxxT1D1t9RhxXlbh+bjiqvW62xsOKBY8CouQth0ug9Ofj/X0q7E1FiFsF2SpzcP06QZ0kak4s+HSTpmuOHLFacmakwCWCmtlrvBjxQZzl4n1uXxCdrJEcHPFCB5qPgMXD4rbUYkTYPikVOcdwV2ppDsCChwEAJgOKZTrQtpb8Ol5WjBhHfZOGpq6P43+boJFYoIQAsVH7fFCLH8WgrOYcT/hRS5EOxoM923wWFz+IX33Bx3NCD56lIsLh9VrqcyIsGSzHXJj1uGSqddsvBhzQajgbEIAOSYis7evbms+RVuYRHPtdh7k3D9+0FAsFgEwLJSG2y4kx5Il7axCWfanNjsfsYskC3bPPYnP6hKFil/Y5ZIQKETL+txyTrE2N9PbJCEDZ4NtcWbPtdB7i/H9+0IQcvz7Y5M+aUZexPqb5IQgSpWVfUd/qEIQf//Z'
+  }
+}
+
+const fetchImage = async (imageSrc: string) => {
+  if (imageSrc.includes('http')) {
+    return fetchRemoteImage(imageSrc)
+  }
+  return fetchLocalImage(imageSrc)
+}
+
+const fetchLocalImage = async (imageSrc: string) => await fs.readFile(`public/${imageSrc}`)
+
+const fetchRemoteImage = async (imageSrc: string) => {
+  const response = await fetch(imageSrc)
+  const buffer = await response.arrayBuffer()
+  return Buffer.from(buffer)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,6 +1755,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@plaiceholder/next@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@plaiceholder/next/-/next-3.0.0.tgz#b35d74286f14fccf8df6793a540d81ac16bca349"
+  integrity sha512-7UK/H1X64hwo2VaxOPKMXE+OY9IgmKLPsq/xKHZ+gU07oqQSfIWWIgpVVucMB3ZgVYah+68agR15BRuSxAuMHw==
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.5":
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.11.tgz#7c2268cedaa0644d677e8c4f377bc8fb304f714a"
@@ -8464,6 +8469,11 @@ pkg-dir@^7.0.0:
   integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
   dependencies:
     find-up "^6.3.0"
+
+plaiceholder@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/plaiceholder/-/plaiceholder-3.0.0.tgz#bd0a3ea0613523e4b8a8239ab7566432880d7fc3"
+  integrity sha512-jwHxxHPnr1BwRzPCeZgEK2BMsEy2327sWynw3qb6XC/oGgGDUTPtR8pFxFQmNArhMBwhkUbUr5OPhhIJpCa8eQ==
 
 pnp-webpack-plugin@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
# Summary

- Created a util function that generates a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) placeholder via [plaiceholder](https://plaiceholder.co/) given an image url, regardless of whether it's a local image or a remote image
- Blur placeholders are now in place for all page headers
- Refactored ContactUs Page and ContactForm component to fully set ContactUs Page as a server-side component (otherwise, we can't generate the blur placeholder since `plaiceholder` can only be used on server-side components)

## ⚠️ IMPORTANT: plaiceholder ⚠️

- You can only use `plaiceholder` on server-side components and functions. We are optimizing images on the server.

## Note

I have a default placeholder in case fetching the image fails: 
![default-placeholder](https://github.com/jadurani/360degrees-company-website/assets/11599005/2b214982-31bb-41a5-a2c8-70a5f9b7774c)

Manually generated the data URL via:
https://www.base64-image.de/

Re-checked in another external service via:
https://jaredwinick.github.io/base64-image-viewer/

## References

- https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating
- https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns
- https://plaiceholder.co/
